### PR TITLE
Pass hostname from vagrant ssh instead of node name to testbeat

### DIFF
--- a/lib/vagrant/noderunner.rb
+++ b/lib/vagrant/noderunner.rb
@@ -7,10 +7,14 @@ require_relative './cookbook_decompiler.rb'
 # dependencies for the lib running node tests, preferrably discovered here instead of in node loop
 require 'rspec'
 require 'set'
+require 'open3'
 
 def get_hostname(node: $node, vagrant_dir: $vagrant_dir)
   [node, vagrant_dir]
-  return node
+  cmd_hostname = "cat /etc/hostname"
+  hostname = Open3.popen3("cd #{ vagrant_dir + node }; vagrant ssh -c \"#{cmd_hostname}\"") { |stdin, stdout, stderr, wait_thr| stdout.read }
+  puts "Vagrant node hostname: #{hostname}"
+  return hostname
 end
 
 # Get first matching subgroup

--- a/lib/vagrant/noderunner.rb
+++ b/lib/vagrant/noderunner.rb
@@ -114,6 +114,7 @@ def run_tests(recipes, hostname, out: "#{$vagrant_dir}#{$node}/generated/", test
   [recipes, hostname, out, testglob, verbose]
   rspec_ok = true # if no tests => no failure
 
+  puts "Starting test run for hostname: #{hostname}"
   if Dir.exists?(out)
     puts "Using existing output directory #{out}"
     Dir.glob("#{out}acceptance*").each do |previous|


### PR DESCRIPTION
Contributed by @takesson.

Starts #4, with the caveat that `@node` instance in testbeat no longer knows about node attributes.

Also `get_hostname` could be made more pluggable.

To restore `@node` for tests that do want to adapt to node config (json), and also align with #2: We could pass two env vars to testbeat, for example NODE and NODE_HOST (or maybe TARGET or something else that is more generic and thus less confusing in docker setups where node is something else).
