### PR TITLE
Support additional session authentication via 'authdenied'

### DIFF
--- a/lib/rspec/spec_helper.rb
+++ b/lib/rspec/spec_helper.rb
@@ -241,6 +241,7 @@ class TestbeatContext
       @session = ENV['TESTBEAT_SESSION']
       if ENV.key?( 'TESTBEAT_SESSION_DENIED' )
         @session_denied = ENV['TESTBEAT_SESSION_DENIED']
+      end
     else
       @user = { :username => 'testuser', :password => 'testpassword' }
     end

--- a/lib/rspec/spec_helper.rb
+++ b/lib/rspec/spec_helper.rb
@@ -348,7 +348,7 @@ class TestbeatContext
   end
 
   def authdenied?
-    unencrypted? || @authdenied
+    @authdenied
   end
 
   def unencrypted?
@@ -479,7 +479,7 @@ class TestbeatRestRequest
           req['Cookie'] = @testbeat.session_denied
         end
       end
-      if @testbeat.user and not @testbeat.unauthenticated?
+      if @testbeat.user and not @testbeat.unauthenticated? and not @testbeat.authdenied?
         # Now using forced Basic Auth. Test the realm by using 'unauthenticated'.
         u = @testbeat.user
         @testbeat.logger.info{ "Authenticating to #{@testbeat.resource} with #{u[:username]}:#{u[:password]}" }
@@ -520,7 +520,7 @@ class TestbeatRestRequest
             req['Cookie'] = @testbeat.session_denied
           end
         end
-        if @testbeat.user and not @testbeat.unauthenticated?
+        if @testbeat.user and not @testbeat.unauthenticated? and not @testbeat.authdenied?
           # Now using forced Basic Auth. Test the realm by using 'unauthenticated'.
           u = @testbeat.user
           @testbeat.logger.info{ "Authenticating to #{@testbeat.resource} with #{u[:username]}:#{u[:password]}" }

--- a/lib/rspec/spec_helper.rb
+++ b/lib/rspec/spec_helper.rb
@@ -415,6 +415,10 @@ class TestbeatContext
       @unauthenticated = true
     }
 
+    /authdenied/i.match(a) {
+      @authdenied = true
+    }
+
     HTTP_VERB_RESOURCE.match(a) { |rest|
       @rest = true
       @method = rest[1]

--- a/lib/rspec/spec_helper.rb
+++ b/lib/rspec/spec_helper.rb
@@ -347,6 +347,10 @@ class TestbeatContext
     unencrypted? || @unauthenticated
   end
 
+  def authdenied?
+    unencrypted? || @authdenied
+  end
+
   def unencrypted?
     @unencrypted
   end
@@ -366,6 +370,8 @@ class TestbeatContext
       s += " unencrypted"
     elsif @unauthenticated
       s += " unauthenticated"
+    elsif @authdenied
+      s += " authdenied"
     end
     s
   end

--- a/testbeat.gemspec
+++ b/testbeat.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name        = 'testbeat'
-  s.version     = '0.8.2'
-  s.date        = '2022-10-15'
+  s.version     = '0.8.3'
+  s.date        = '2022-12-12'
   s.summary     = 'REST acceptance testing framework'
   s.description = 'Rspec spec_helper and Vagrant integration for HTTP level testing, on a box from the outside'
   s.authors     = ['Staffan Olsson']


### PR DESCRIPTION
Support additional session authentication via 'authdenied' used when testing that OpenIDC Claims are evaluated.